### PR TITLE
when redis handle goes away, skip processing

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,9 +1,10 @@
 
-# 1.0.2 - 2017-02-06
+## 1.0.2 - 2017-02-06
 
 - when redis handle goes away, skip processing
+- add a 5 minute expiration on outbound rate limit entries
 
-# 1.0.1 - 2017-01-28
+## 1.0.1 - 2017-01-28
 
 - increment rate_conn on connect_init
 - increment rate_rcpt_host on rcpt/rcpt_ok

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-limit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "enforce various types of limits on remote MTAs",
   "main": "limit.js",
   "directories": {


### PR DESCRIPTION
- add a 5 minute expiration on outbound rate limit entries