### PR TITLE
Release v1.0.7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-type: "production"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     uses: haraka/.github/.github/workflows/lint.yml@master
 
   test:
-    needs: lint
+    needs: get-lts
     runs-on: ${{ matrix.os }}
     services:
       redis:
@@ -24,15 +24,23 @@ jobs:
         os:
           - ubuntu-latest
           # - windows-latest  (no redis yet)
-        node-version: [ 14, 16, 18 ]
+        node-version: ${{ fromJson(needs.get-lts.outputs.active) }}
       fail-fast: false
-
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       name: Node ${{ matrix.node-version }} on ${{ matrix.os }}
       with:
         node-version: ${{ matrix.node-version }}
-
     - run: npm install
     - run: npm test
+
+  get-lts:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - id: get
+        uses: msimerson/node-lts-versions@v1.3.2
+    outputs:
+      active: ${{ steps.get.outputs.active }}
+      lts:    ${{ steps.get.outputs.lts }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".release"]
+	path = .release
+	url = https://github.com/msimerson/.release

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@
 - chore: add .release as a submodule
 - ci: limit dependabot updates to production deps
 - ci: populate test matrix with Node.js LTS versions
+- cfg: rename redis.db -> redis.database, pi-redis 2+ does this automatically, causing a test failure
 
 
 ### 1.0.6 - 2022-05-25

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,8 @@
 
 - chore: add .release as a submodule
 - ci: limit dependabot updates to production deps
+- ci: populate test matrix with Node.js LTS versions
+
 
 ### 1.0.6 - 2022-05-25
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,11 @@
 
+### Unreleased
+
+### [1.0.7] - 2022-06-03
+
+- chore: add .release as a submodule
+- ci: limit dependabot updates to production deps
+
 ### 1.0.6 - 2022-05-25
 
 - feat: update redis commands to be v4 compatible
@@ -36,3 +43,6 @@
 
 - increment rate_conn on connect_init
 - increment rate_rcpt_host on rcpt/rcpt_ok
+
+
+[1.0.7]: https://github.com/haraka/haraka-plugin-limit/releases/tag/1.0.7

--- a/config/limit.ini
+++ b/config/limit.ini
@@ -6,7 +6,7 @@ tarpit_delay=3
 [redis]
 ; host=127.0.0.1
 ; port=6387
-db=4
+database=4
 ;
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-limit",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "enforce various types of limits on remote MTAs",
   "main": "index.js",
   "directories": {

--- a/test/config.js
+++ b/test/config.js
@@ -16,7 +16,7 @@ const default_config = {
     rate_rcpt_host: { '127': 0, enabled: false, default: '50/5m' },
     rate_rcpt_sender: { '127': 0, enabled: false, default: '50/5m' },
     rate_rcpt_null: { enabled: false, default: 1 },
-    redis: { db: 4, socket: { host: '127.0.0.1', port: '6379' } },
+    redis: { database: 4, socket: { host: '127.0.0.1', port: '6379' } },
     concurrency: { plugin: 'karma', good: 10, bad: 1, none: 2 }
 };
 

--- a/test/config/limit.ini
+++ b/test/config/limit.ini
@@ -6,7 +6,7 @@ tarpit_delay=0
 [redis]
 ; host=127.0.0.1
 ; port=6387
-db=4
+database=4
 ;
 
 


### PR DESCRIPTION
- ci: populate test matrix with Node.js LTS versions
- ci: limit dependabot updates to production deps
- doc(README): remove broken lint badge
- closes #40 