### PR TITLE
initialize redis when only concurrency is enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ exports.register = function () {
     let needs_redis = 0
 
     if (this.cfg.concurrency.enabled) {
+        needs_redis++;
         this.register_hook('connect_init', 'conn_concur_incr');
         this.register_hook('connect',      'check_concurrency');
         this.register_hook('disconnect',   'conn_concur_decr');
@@ -30,25 +31,25 @@ exports.register = function () {
     }
 
     if (this.cfg.rate_conn.enabled) {
-        needs_redis++
+        needs_redis++;
         this.register_hook('connect_init', 'rate_conn_incr');
         this.register_hook('connect',      'rate_conn_enforce');
     }
     if (this.cfg.rate_rcpt_host.enabled) {
-        needs_redis++
+        needs_redis++;
         this.register_hook('connect', 'rate_rcpt_host_enforce');
         this.register_hook('rcpt',    'rate_rcpt_host_incr');
     }
     if (this.cfg.rate_rcpt_sender.enabled) {
-        needs_redis++
+        needs_redis++;
         this.register_hook('rcpt', 'rate_rcpt_sender');
     }
     if (this.cfg.rate_rcpt_null.enabled) {
-        needs_redis++
+        needs_redis++;
         this.register_hook('rcpt', 'rate_rcpt_null');
     }
     if (this.cfg.rate_rcpt.enabled) {
-        needs_redis++
+        needs_redis++;
         this.register_hook('rcpt', 'rate_rcpt');
     }
 


### PR DESCRIPTION
When _only_ concurrency is enabled, redis is not initialized. This ends up causing an exception:

```
[CRIT] [C0FB6832-B453-4430-B2F3-E9D501B38F6B] [core] Plugin limit failed: TypeError: Cannot read properties of undefined (reading 'concurrent_count')
    at Plugin.exports.check_concurrency (/app/code/haraka/node_modules/haraka-plugin-limit/index.js:239:61)
    at Object.plugins.run_next_hook (/app/code/haraka/plugins.js:540:28)
    at callback (/app/code/haraka/plugins.js:493:32)
    at /app/code/haraka/plugins/dnsbl.js:149:16
    at zonesDone (/app/code/haraka/plugins/dns_list_base.js:128:9)
    at wrapper (/app/code/haraka/node_modules/async/dist/async.js:271:20)
    at iteratorCallback (/app/code/haraka/node_modules/async/dist/async.js:501:17)
    at /app/code/haraka/node_modules/async/dist/async.js:327:20
    at /app/code/haraka/plugins/dns_list_base.js:124:13
    at QueryReqWrap.callback (/app/code/haraka/plugins/dns_list_base.js:58:24)
```

My config:
```
[unrecognized_commands]
enabled=true
max=10

[errors]
enabled=true
max=5

[concurrency]
enabled=true
max=200
```