### PR TITLE
Fix type error in redis usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -480,7 +480,7 @@ exports.rate_conn_incr = async function (next, connection) {
     if (!key || !value) return next();
 
     try {
-        await this.db.hIncrBy(`rate_conn:${key}`, (+ new Date()).toString(), 1)
+        await this.db.hincrby(`rate_conn:${key}`, (+ new Date()).toString(), 1)
         // extend key expiration on every new connection
         await this.db.expire(`rate_conn:${key}`, getTTL(value) * 2)
     }
@@ -598,7 +598,7 @@ exports.outbound_increment = async function (next, hmail) {
     const outKey = getOutKey(outDom);
 
     try {
-        let count = await this.db.hIncrBy(outKey, 'TOTAL', 1)
+        let count = await this.db.hincrby(outKey, 'TOTAL', 1)
 
         this.db.expire(outKey, 300);  // 5 min expire
 
@@ -621,6 +621,6 @@ exports.outbound_increment = async function (next, hmail) {
 exports.outbound_decrement = function (next, hmail) {
     if (!this.db) return next();
 
-    this.db.hIncrBy(getOutKey(getOutDom(hmail)), 'TOTAL', -1);
+    this.db.hincrby(getOutKey(getOutDom(hmail)), 'TOTAL', -1);
     next();
 }


### PR DESCRIPTION
Without this, I get the following stack trace:

```
TypeError: this.db.hIncrBy is not a function
    at Plugin.exports.rate_conn_incr (/app/code/haraka/node_modules/haraka-plugin-limit/index.js:492:23)
    at Object.plugins.run_next_hook (/app/code/haraka/plugins.js:540:28)
    at callback (/app/code/haraka/plugins.js:493:32)
    at Plugin.exports.conn_concur_incr (/app/code/haraka/node_modules/haraka-plugin-limit/index.js:225:5)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```