### PR TITLE
disable history config by default

### DIFF
--- a/config/limit.ini
+++ b/config/limit.ini
@@ -20,10 +20,10 @@ max=3
 ; History: when enabled, the plugin is one which stores IP history. The history
 ;    plugin results must have a positive integers for good connections negative
 ;    integers for poor / undesirable connections. Karma is one such plugin.
-plugin=karma
-good=10
-bad=1
-none=2
+; plugin=karma
+; good=10
+; bad=1
+; none=2
 
 
 ;                             RECIPIENT LIMITS
@@ -34,12 +34,12 @@ none=2
 ; max_relaying=100
 
 
-[recipients_history]
+; [recipients_history]
 ;     The same history notes for [concurrency] apply here.
-plugin=karma
-bad=1
-none=5
-good=50
+; plugin=karma
+; bad=1
+; none=5
+; good=50
 
 
 ;                         UNRECOGNIZED COMMAND LIMITS
@@ -67,11 +67,11 @@ max=10
 default=5
 
 ; The history notes for [concurrency] apply here too.
-[rate_conn_history]
-plugin=karma
-bad=1/15m
-none=1/5m
-good=15/1m
+; [rate_conn_history]
+; plugin=karma
+; bad=1/15m
+; none=1/5m
+; good=15/1m
 
 
 ;                       RECIPIENT RATE LIMITS by HOST


### PR DESCRIPTION
also, because of a commenting error, the "concurrency" section ended up having the configuration meant for "concurrency_history"